### PR TITLE
Name prefix

### DIFF
--- a/lib/esshorten.js
+++ b/lib/esshorten.js
@@ -74,16 +74,20 @@
             return true;
         }
 
-        generateName(tip) {
+        generateName(tip, prefix) {
+            if (!prefix) {
+                prefix = '';
+            }
             do {
                 tip = utility.generateNextName(tip);
-            } while (!this.passAsUnique(tip));
-            return tip;
+            } while (!this.passAsUnique(prefix + tip));
+            return prefix + tip;
         }
     }
 
     const run = (scope, options) => {
         let generator = new NameGenerator(scope, options);
+        let prefix = options.renamePrefix;
 
         const shouldRename = options && options.shouldRename || () => true;
 
@@ -114,7 +118,7 @@
                     continue;
                 }
 
-                name = generator.generateName(name);
+                name = generator.generateName(name, prefix);
 
                 for (let def of variable.identifiers) {
                     // change definition's name

--- a/test/mangle.coffee
+++ b/test/mangle.coffee
@@ -184,3 +184,11 @@ describe 'mangle:', ->
                     return id != 'name'
 
             expect(result.body[0].expression.id.name).to.equal 'name'
+
+    describe '`renamePrefix` option:', ->
+        program = esprima.parse '(function name() { var i = 42; });'
+
+        it 'prefixes identifier with the given value', ->
+            result = esshorten.mangle program,
+                renamePrefix: 'foo_'
+            expect(result.body[0].expression.id.name.indexOf('foo_')).to.equal 0


### PR DESCRIPTION
This implements a `renamePrefix` option that allows you to set prefixes on all the identifiers generated by esshorten. There's also a basic unit test.