### PR TITLE
Fixes bug that was causing prefix to be added multiple times

### DIFF
--- a/lib/esshorten.js
+++ b/lib/esshorten.js
@@ -78,6 +78,9 @@
             if (!prefix) {
                 prefix = '';
             }
+            if (tip.indexOf(prefix) === 0) {
+                tip = tip.substr(prefix.length);
+            }
             do {
                 tip = utility.generateNextName(tip);
             } while (!this.passAsUnique(prefix + tip));

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "http://github.com/estools/esshorten.git"
   },
   "dependencies": {
-    "escope": "~3.3.0",
+    "escope": "^1.0.0",
     "estraverse": "~4.1.1",
     "esutils": "~2.0.2"
   },

--- a/test/mangle.coffee
+++ b/test/mangle.coffee
@@ -186,9 +186,17 @@ describe 'mangle:', ->
             expect(result.body[0].expression.id.name).to.equal 'name'
 
     describe '`renamePrefix` option:', ->
-        program = esprima.parse '(function name() { var i = 42; });'
 
         it 'prefixes identifier with the given value', ->
+            program = esprima.parse '(function name() { var i = 42; });'
             result = esshorten.mangle program,
                 renamePrefix: 'foo_'
             expect(result.body[0].expression.id.name.indexOf('foo_')).to.equal 0
+
+        it 'prefixes identifier inside IIFE without multiplying prefixes', ->
+            program = esprima.parse '(function name() { var i = 42; var a = 5; })();'
+            result = esshorten.mangle program,
+                renamePrefix: 'foo_'
+
+            expect(result.body[0].expression.callee.body.body[1].declarations[0].id.name.indexOf('foo_')).to.equal 0
+            expect(result.body[0].expression.callee.body.body[1].declarations[0].id.name.indexOf('foo_foo_')).to.equal -1


### PR DESCRIPTION
This bug was introduced by our PR #18. It was causing the namePrefix to be added multiple times to renamed variables in some scenarios (ie: IIFE).

Here is an example of what was happening:  

``` javascript
(function () {
  var variableA = 1;
  var variableB = 2;
  var variableC = 3;
})();
```

When we mangled the tree with `_` as namePrefix:

``` javascript
(function () {
  var _a = 1;
  var __b = 2;
  var ___c = 3;
})();
```
