### PR TITLE
Fix node11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ language: node_js
 node_js:
   - "5"
   - "4"
+  - "stable"

--- a/lib/esshorten.js
+++ b/lib/esshorten.js
@@ -89,7 +89,7 @@
         let generator = new NameGenerator(scope, options);
         let prefix = options.renamePrefix;
 
-        const shouldRename = options && options.shouldRename || () => true;
+        const shouldRename = options && options.shouldRename || (() => true);
 
         if (scope.isStatic()) {
             let name = '9';

--- a/lib/esshorten.js
+++ b/lib/esshorten.js
@@ -94,6 +94,10 @@
         if (scope.isStatic()) {
             let name = '9';
 
+            scope.variables.forEach((variable, index) => {
+                variable.originalVariableIndex = index;
+            });
+
             scope.variables.sort((a, b) => {
                 if (a.tainted) {
                     return 1;
@@ -101,7 +105,9 @@
                 if (b.tainted) {
                     return -1;
                 }
-                return (b.identifiers.length + b.references.length) - (a.identifiers.length + a.references.length);
+
+                let diff = (b.identifiers.length + b.references.length) - (a.identifiers.length + a.references.length);
+                return diff === 0 ? a.originalVariableIndex - b.originalVariableIndex : diff;
             });
 
             for (let variable of scope.variables) {

--- a/test/mangle.coffee
+++ b/test/mangle.coffee
@@ -79,6 +79,14 @@ describe 'mangle:', ->
             expect(f.params[0].name).not.to.equal a.body.body[0].expression.name
             expect(a.id.name).not.to.equal a.body.body[0].expression.name
 
+        it 'sort for node11', ->
+            program = esprima.parse 'function f(a1, a2, a3, a4, a5) { var b1, b2, b3, b4, b5 }'
+
+            result = esshorten.mangle program
+            expect(result.body[0].params[0].name).to.equal 'a'
+            expect(result.body[0].body.body[0].declarations[0].id.name).to.equal 'f'
+
+
     describe 'nested scope handling:', ->
         it 'shortens nested function names', ->
             program = esprima.parse 'function f() { function g() {} }'


### PR DESCRIPTION
Node11 and Node8 sort results are different when return 0 by `Array.sort`.
This causes the generated variable names to be inconsistent in different versions.